### PR TITLE
Ignore gke added labels and taints on node pools

### DIFF
--- a/pkg/clients/nodepool/nodepool.go
+++ b/pkg/clients/nodepool/nodepool.go
@@ -360,6 +360,9 @@ func IsUpToDate(name string, in *v1alpha1.NodePoolParameters, observed *containe
 	if !cmp.Equal(desired.Management, observed.Management, cmpopts.EquateEmpty()) {
 		return false, newManagementUpdateFn(in.Management), nil
 	}
+
+	// TODO(hasheddan): remove manual ignore functions when resolution is
+	// reached on https://github.com/crossplane/crossplane-runtime/issues/120
 	if !cmp.Equal(desired, observed, cmpopts.EquateEmpty(), cmpopts.IgnoreSliceElements(func(c *container.NodeTaint) bool {
 		return c.Key == runtimeKey
 	}), cmpopts.IgnoreMapEntries(func(key, _ string) bool {

--- a/pkg/clients/nodepool/nodepool_test.go
+++ b/pkg/clients/nodepool/nodepool_test.go
@@ -578,6 +578,44 @@ func TestIsUpToDate(t *testing.T) {
 				isErr:    false,
 			},
 		},
+		"UpToDateIgnoreGVisor": {
+			args: args{
+				name: name,
+				nodePool: nodePool(addOutputFields, func(n *container.NodePool) {
+					n.Config = &container.NodeConfig{
+						Labels: map[string]string{
+							"cool-key": "cool-value",
+							runtimeKey: "any value here ignored",
+						},
+						Taints: []*container.NodeTaint{
+							{
+								Key:   "cool-key",
+								Value: "cool-value",
+							},
+							{
+								Key:   runtimeKey,
+								Value: "any value here ignored",
+							},
+						},
+					}
+				}),
+				params: params(func(p *v1alpha1.NodePoolParameters) {
+					p.Config = &v1alpha1.NodeConfig{
+						Labels: map[string]string{"cool-key": "cool-value"},
+						Taints: []*v1alpha1.NodeTaint{
+							{
+								Key:   "cool-key",
+								Value: "cool-value",
+							},
+						},
+					}
+				}),
+			},
+			want: want{
+				upToDate: true,
+				isErr:    false,
+			},
+		},
 		"NeedsUpdate": {
 			args: args{
 				name: name,


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Modifies `UpToDate` logic for `NodePool` to ignore `Labels` and `Taints` with key `sandbox.gke.io/runtime`, which GCP adds automatically when certain sandbox configuration is provided (i.e. `gVisor`).

Ref: https://github.com/crossplane/crossplane-runtime/issues/120

Additional context on why a user can't manually provide these fields:
```
- lastTransitionTime: "2020-02-21T21:39:45Z" 
  message: 'create failed: cannot create GKE node pool: googleapi: Error 400:
    Node label "sandbox.gke.io/runtime" is reserved for gke sandbox., badRequest'
  reason: Encountered an error during resource reconciliation
  status: "False"
  type: Synced
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/resources
