### PR TITLE
Remove string marshalling tag to fix nodepool accelerators field

### DIFF
--- a/apis/container/v1alpha1/nodepool_types.go
+++ b/apis/container/v1alpha1/nodepool_types.go
@@ -433,7 +433,7 @@ type NodeConfig struct {
 type AcceleratorConfig struct {
 	// AcceleratorCount: The number of the accelerator cards exposed to an
 	// instance.
-	AcceleratorCount int64 `json:"acceleratorCount,omitempty,string"`
+	AcceleratorCount int64 `json:"acceleratorCount,omitempty"`
 
 	// AcceleratorType: The accelerator type resource name. List of
 	// supported accelerators

--- a/apis/container/v1beta1/gkecluster_types.go
+++ b/apis/container/v1beta1/gkecluster_types.go
@@ -1475,7 +1475,7 @@ type NodeConfigClusterStatus struct {
 type AcceleratorConfigClusterStatus struct {
 	// AcceleratorCount: The number of the accelerator cards exposed to an
 	// instance.
-	AcceleratorCount int64 `json:"acceleratorCount,omitempty,string"`
+	AcceleratorCount int64 `json:"acceleratorCount,omitempty"`
 
 	// AcceleratorType: The accelerator type resource name. List of
 	// supported accelerators

--- a/examples/container/kubernetescluster/resource-claim.yaml
+++ b/examples/container/kubernetescluster/resource-claim.yaml
@@ -3,7 +3,7 @@ apiVersion: compute.crossplane.io/v1alpha1
 kind: KubernetesCluster
 metadata:
   name: app-kubernetes
-  label:
+  labels:
     example: "true"
 spec:
   classSelector:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Fixes `acceleratorCount` field of NodePools. The marshalling gets crazy when you got `,string"` for a non-string type.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/resources
